### PR TITLE
Pré-Compilação - JOB de exclusão

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ PATH=C:\caminho\qualquer\da\sua\maquina
 ENVIRONMENT=AMBIENTE_QUE_EXISTA
 ```
 
+[AMBIENTE_QUE_EXISTA]
+ROOTPATH=C:\caminho\qualquer\da\sua\maquina\Protheus_Data
+DIRINCLUDE:C:\caminho\qualquer\da\sua\maquina\Includes
+
+Obs.: Caso o diretório de includes [DIRINCLUDE] não
+seja informado, a pré-compilação não é executada.
 
 Como utilizar
 =============

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ PATH=C:\caminho\qualquer\da\sua\maquina
 ENVIRONMENT=AMBIENTE_QUE_EXISTA
 ```
 
+```
 [AMBIENTE_QUE_EXISTA]
 ROOTPATH=C:\caminho\qualquer\da\sua\maquina\Protheus_Data
 DIRINCLUDE:C:\caminho\qualquer\da\sua\maquina\Includes
+```
 
 Obs.: Caso o diretório de includes [DIRINCLUDE] não
 seja informado, a pré-compilação não é executada.
+
 
 Como utilizar
 =============

--- a/editor.aph
+++ b/editor.aph
@@ -42,7 +42,7 @@
             </div>
             <div class="w3-dropdown-hover w3-mobile">
                 <span class="w3-button">Pesquisar no TDN</span>
-                <div class="w3-dropdown-content w3-card-4">
+                <div class="w3-dropdown-content w3-bar-block w3-card-4">
                     <input id="get_tdn" type="text" class="w3-input w3-border" name="entry" placeholder="Digite sua pesquisa aqui"/>
                     <button id="btn_tdn" class="w3-btn w3-theme-d4" style="width: 100%">Pesquisar &#128270;</button>
                 </div>


### PR DESCRIPTION
Criação de job para exclusão dos RPOs gerados pela ferramenta AdvPlayL, para isso o RPO passou a ser gerado conforme o diretório presente na chave **SOURCEPATH**.
O job é executado sempre que uma compilação é executada, possuindo um controle em variáveis globais para não rodar uma vez atrás da outra, sendo executado no máximo de quinze em quinze minutos.

Atualização da ferramenta para trabalhar com includes pela chave de ambiente **DIRINCLUDE**, uma vez que esse diretório é informado e encontrado, é possível usar o pré-compilador e tratar questões como #Define, #XTranslate e #XCommand.